### PR TITLE
Define slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+### 5.0.0
+* Due to the nature of this update most object constructor signatures have been changed and will need to be updated
+* Slugs are no longer generated automatically but required on object instantiation
+
 ### 4.0.0
 
-* Due to the nature of this update most object constructor signatures have been updated
+* Due to the nature of this update most object constructor signatures have been changed and will need to be updated
 * View class made static
 * $viewFile property added to WordPressObject class
 * $viewData property added to WordPressObject class

--- a/README.md
+++ b/README.md
@@ -50,21 +50,10 @@ WordPressObject parent class. This is optional, the text domain has a default va
 
 #### getSlug()
 
-Slugs are automatically generated for all objects other than Settings.
+This public method returns the object's slug. A slug is a unique identifier for the object in the WordPress database.
+This method is used within the framework to tie related objects together.
 
-The public method getSlug() returns an object's $name property after passing it through the WordPress
-[sanitize_title()](http://codex.wordpress.org/Function_Reference/sanitize_title) function and returns that value. In the
- case of SettingsField getSlug() will also append the prefix.
-
-This is useful for anytime you need to get the slug or ID of an object to use later in the code.
-
-Getting an option value:
-
-    get_option($field->getSlug());
-
-Setting a parent page for a sub page:
-
-    $subPage->setParentSlug($parentPage->getSlug());
+    echo $someObject->getSlug();
 
 #### getName()
 
@@ -80,8 +69,8 @@ View class' render() method passing in the object's $viewFile and $viewData prop
 
 ### PostType
 
-The PostType class constructor requires the name of the post type to be created. The name must be plural for the labels
-to be generated correctly.
+The PostType class constructor requires the name of the post type and a slug to be created. The name must be plural for
+the labels to be generated correctly.
 
 The PostType class constructor generates the labels for the post type and then ties the
 [register_post_type()](http://codex.wordpress.org/Function_Reference/register_post_type) function to the
@@ -157,8 +146,8 @@ __false__ to disable all features.
 
 ### Taxonomies
 
-The Taxonomy class requires the plural display name of the taxonomy when instantiated. Optionally, the post types to
-register the taxonomy with (defaults to post) and the text domain.
+The Taxonomy class requires the plural display name of the taxonomy and a slug when instantiated. Optionally, the post
+types to register the taxonomy with (defaults to post) and the text domain.
 
 The constructor sets up the properties, generates the labels, and ties the
 [register_taxonomy()](http://codex.wordpress.org/Function_Reference/register_taxonomy) function  to the
@@ -175,8 +164,9 @@ take the term description. This method checks if the term has already been added
 
 ### MetaBoxes
 
-Meta boxes containing custom fields can be added to your post types using this class. The object requires the name,
-post type slugs to attach it to, and a view file when instantiated. View data can be passed in optionally.
+Meta boxes containing custom fields can be added to your post types using this class. The object requires the name, slug
+ for the meta box, post type slugs to attach it to, and a view file when instantiated. View data can be passed in
+ optionally.
 
 The constructor sets the properties then ties the addMetaBox() method to the
 [add_meta_boxes](http://codex.wordpress.org/Plugin_API/Action_Reference/add_meta_boxes) hook and the saveMetaBox()
@@ -219,8 +209,8 @@ This sets an array of optional arguments that will be sent to the MetaBox's View
 You can create new dashboard pages by using the MenuPage, ObjectPage, UtilityPage, SubMenuPage, and OptionsPage classes.
  All page classes inherit from the Page abstract class.
 
-All page classes require a name and view file when instantiated, $viewData can be passed in optionally.  The slug and
-name are added to the $viewData array automatically.
+All page classes require a name, slug, and view file when instantiated, $viewData can be passed in optionally.  The slug
+ and name are added to the $viewData array automatically.
 
 The base constructor sets the parameters then ties the abstract addPage() method to the
 [admin_menu](http://codex.wordpress.org/Plugin_API/Action_Reference/admin_menu) hook. This addPage() method is
@@ -320,7 +310,7 @@ The Settings constructor requires the slug for the page the settings will be dis
 
 #### SettingsFields
 
-The SettingsField constructor requires a name, prefix, and a view file to be passed in. View data can be passed in as
+The SettingsField constructor requires a name, slug, and a view file to be passed in. View data can be passed in as
 well.
 
 You must specify a prefix for your field's slugs to help prevent naming conflicts in the database by using the $prefix
@@ -333,7 +323,8 @@ the $viewData property automatically.
 
 #### SettingsSection
 
-The SettingsSection class requires a name to be instantiated. A view file and view data can be passed in, optionally.
+The SettingsSection class requires a name and slug to be instantiated. A view file and view data can be passed in,
+optionally.
 
 Unless you need to display something specific like instructions to the user you do not need to include a view file since
 WordPress will automatically display the section's name on the page.
@@ -368,7 +359,7 @@ or...
 
 You can use the DashboardWidget class to add a new widget to the WordPress dashboard.
 
-The class takes a name and path to a view file when instantiated. Data you need to pass to the view can be supplied in
+The class takes a name, slug, and path to a view file when instantiated. Data you need to pass to the view can be supplied in
 the optional $viewData argument. The DashboardWidget's name and slug are automatically added to the $viewData.
 
 The constructor assigns the properties and ties the addWidget() method to the

--- a/src/DashboardWidget.php
+++ b/src/DashboardWidget.php
@@ -18,12 +18,14 @@ class DashboardWidget extends WordPressObject
      * @since 3.0.0
      *
      * @param string $name The name your widget will display in its heading.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      * @param string $viewFile The full path to the object's view file.
      * @param mixed[] $viewData An array of data to pass to the view file.
      */
-    public function __construct($name, $viewFile, $viewData = array())
+    public function __construct($name, $slug, $viewFile, $viewData = array())
     {
         $this->name             = $name;
+        $this->slug             = $slug;
         $this->viewFile         = $viewFile;
         $this->viewData         = $viewData;
         $this->viewData['name'] = $this->getName();

--- a/src/MetaBox.php
+++ b/src/MetaBox.php
@@ -24,13 +24,15 @@ class MetaBox extends WordPressObject
      * @since 3.0.0
      *
      * @param string $name Title of the edit screen section, visible to user.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      * @param string|string[] $postTypes The type of Write screen on which to show the edit screen section.
      * @param string $viewFile The View object responsible for printing out the HTML for the edit screen section.
      * @param mixed[] $viewData An array of data to pass to the view file.
      */
-    function __construct($name, $postTypes, $viewFile, $viewData = array())
+    function __construct($name, $slug, $postTypes, $viewFile, $viewData = array())
     {
         $this->name             = $name;
+        $this->slug             = $slug;
         $this->viewFile         = $viewFile;
         $this->viewData         = $viewData;
         $this->viewData['name'] = $this->getName();

--- a/src/Page.php
+++ b/src/Page.php
@@ -27,12 +27,14 @@ abstract class Page extends WordPressObject
      * @since 0.1.0
      *
      * @param string $name The text to be displayed in the title tags of the page when the menu is selected.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      * @param string $viewFile The full path to the view file.
      * @param mixed[] $viewData An array of data to pass to the view file.
      */
-    public function __construct($name, $viewFile, $viewData = array())
+    public function __construct($name, $slug, $viewFile, $viewData = array())
     {
         $this->name             = $name;
+        $this->slug             = $slug;
         $this->viewFile         = $viewFile;
         $this->viewData         = $viewData;
         $this->viewData['name'] = $this->getName();

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -43,10 +43,12 @@ class PostType extends WordPressObject
      * @since 0.1.0
      *
      * @param string $name General name for the post type, must be plural.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      */
-    function __construct($name)
+    function __construct($name, $slug)
     {
         $this->name   = $name;
+        $this->slug   = $slug;
         $this->labels = $this->setLabels();
 
         add_action('init', array($this, 'registerPostType'));
@@ -61,25 +63,24 @@ class PostType extends WordPressObject
      */
     private function setLabels()
     {
-        $name     = $this->name;
-        $singular = Helper::makeSingular($name);
+        $singular = Helper::makeSingular($this->name);
 
         $textDomain = parent::$textDomain;
 
         $labels = array(
-            'name'               => __($name, $textDomain),
+            'name'               => __($this->name, $textDomain),
             'singular_name'      => __($singular, $textDomain),
             'add_new'            => __('Add New', $textDomain),
             'add_new_item'       => __('Add New ' . $singular, $textDomain),
             'edit_item'          => __('Edit ' . $singular, $textDomain),
             'new_item'           => __('New ' . $singular, $textDomain),
-            'all_items'          => __('All ' . $name, $textDomain),
+            'all_items'          => __('All ' . $this->name, $textDomain),
             'view_item'          => __('View ' . $singular, $textDomain),
-            'search_items'       => __('Search ' . $name, $textDomain),
-            'not_found'          => __('No ' . strtolower($name) . ' found.', $textDomain),
-            'not_found_in_trash' => __('No ' . strtolower($name) . ' found in Trash.', $textDomain),
+            'search_items'       => __('Search ' . $this->name, $textDomain),
+            'not_found'          => __('No ' . strtolower($this->name) . ' found.', $textDomain),
+            'not_found_in_trash' => __('No ' . strtolower($this->name) . ' found in Trash.', $textDomain),
             'parent_item_colon'  => '',
-            'menu_name'          => __($name, $textDomain)
+            'menu_name'          => __($this->name, $textDomain)
         );
 
         return $labels;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -68,10 +68,12 @@ class Settings extends WordPressObject
      */
     private function addSection(SettingsSection $section)
     {
-        if (array_key_exists($section->getSlug(), $this->settingsSections)) {
-            wp_die(__("A section with ID {$section->getSlug()} was already added to the settings for the {$this->pageSlug} page.", parent::$textDomain));
+        $sectionSlug = $section->getSlug();
+
+        if (array_key_exists($sectionSlug, $this->settingsSections)) {
+            wp_die(__("A section with ID {$sectionSlug} was already added to the settings for the {$this->pageSlug} page.", parent::$textDomain));
         } else {
-            $this->settingsSections[$section->getSlug()] = $section;
+            $this->settingsSections[$sectionSlug] = $section;
         }
 
         return $this;

--- a/src/SettingsField.php
+++ b/src/SettingsField.php
@@ -9,38 +9,23 @@ namespace theantichris\SPF;
  */
 class SettingsField extends WordPressObject
 {
-    /** @var string An identifier that will be prefixed to the ID to prevent naming conflicts in the database. */
-    private $prefix;
-
     /**
      * Assigns properties and sets up the view.
      *
      * @since 2.0.0
      *
      * @param string $name Title of the field. Used to generate the slug.
-     * @param string $prefix An identifier that will be prefixed to the ID to prevent naming conflicts in the database.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      * @param string $viewFile The full path to the view file.
      * @param mixed[] $viewData An array of data to pass to the view file.
      */
-    public function __construct($name, $prefix, $viewFile, $viewData = array())
+    public function __construct($name, $slug, $viewFile, $viewData = array())
     {
-        $this->prefix           = $prefix;
         $this->name             = $name;
+        $this->slug             = $slug;
         $this->viewData         = $viewData;
         $this->viewFile         = $viewFile;
         $this->viewData['name'] = $this->getName();
         $this->viewData['slug'] = $this->getSlug();
-    }
-
-    /**
-     * Returns a the sanitized name appended with the prefix.
-     *
-     * @since 2.0.0
-     *
-     * @return string
-     */
-    public function getSlug()
-    {
-        return $this->prefix . '-' . sanitize_title($this->name);
     }
 } 

--- a/src/SettingsSection.php
+++ b/src/SettingsSection.php
@@ -18,12 +18,14 @@ class SettingsSection extends WordPressObject
      * @since 2.0.0
      *
      * @param string $name Title of the section. Used to generate the slug.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      * @param string $viewFile The full path to the view file.
      * @param mixed[] $viewData An array of data to pass to the view file.
      */
-    public function __construct($name, $viewFile = '', $viewData = array())
+    public function __construct($name, $slug, $viewFile = '', $viewData = array())
     {
         $this->name = $name;
+        $this->slug = $slug;
 
         if (!empty($viewFile)) {
             $this->viewFile         = $viewFile;
@@ -84,7 +86,7 @@ class SettingsSection extends WordPressObject
         $fieldSlug = $field->getSlug();
 
         if (array_key_exists($fieldSlug, $this->settingsFields)) {
-            wp_die(__("A field with ID {$fieldSlug} was already added to the settings section {$this->getSlug()} page.", parent::$textDomain));
+            wp_die(__("A field with ID {$fieldSlug} was already added to the settings section {$this->getSlug()}.", parent::$textDomain));
         } else {
             $this->settingsFields[$fieldSlug] = $field;
         }

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -27,11 +27,13 @@ class Taxonomy extends WordPressObject
      * @since 0.1.0
      *
      * @param string $name The name of the taxonomy. Must be plural.
+     * @param string $slug Unique identifier for the object in the WordPress database.
      * @param string|string[] $postTypes Slug of the object type for the taxonomy object. Object-types can be built-in Post Type or any Custom Post Type that may be registered.
      */
-    public function __construct($name, $postTypes = 'post')
+    public function __construct($name, $slug, $postTypes = 'post')
     {
         $this->name      = $name;
+        $this->slug      = $slug;
         $this->postTypes = $postTypes;
         $this->labels    = $this->setLabels();
 
@@ -46,16 +48,15 @@ class Taxonomy extends WordPressObject
      */
     private function setLabels()
     {
-        $name     = $this->name;
-        $singular = Helper::makeSingular($name);
+        $singular = Helper::makeSingular($this->name);
 
         $textDomain = parent::$textDomain;
 
         return array(
-            'name'              => __($name, $textDomain),
+            'name'              => __($this->name, $textDomain),
             'singular_name'     => __($singular, $textDomain),
-            'search_items'      => __('Search ' . $name, $textDomain),
-            'all_items'         => __('All ' . $name, $textDomain),
+            'search_items'      => __('Search ' . $this->name, $textDomain),
+            'all_items'         => __('All ' . $this->name, $textDomain),
             'parent_item'       => __('Parent ' . $singular, $textDomain),
             'parent_item_colon' => __('Parent ' . $singular . ':', $textDomain),
             'edit_item'         => __('Edit ' . $singular, $textDomain),

--- a/src/WordPressObject.php
+++ b/src/WordPressObject.php
@@ -13,7 +13,7 @@ abstract class WordPressObject
     public static $textDomain = 'default';
     /** @var string Name or title of the WordPress object. */
     protected $name;
-    /** @var  string Unique identifier for the object in the WordPress database. */
+    /** @var string Unique identifier for the object in the WordPress database. */
     protected $slug;
     /** @var string The full path to the object's view file. */
     protected $viewFile;


### PR DESCRIPTION
Slugs are now required upon object creation instead of generated automatically. This prevents problems that came up with objects were renamed and the slug was regenerated.
