### PR TITLE
New Metaboxes and extended Post Type

### DIFF
--- a/src/MetaBoxViews/AssociativeAutoCompleteInput.php
+++ b/src/MetaBoxViews/AssociativeAutoCompleteInput.php
@@ -1,0 +1,32 @@
+<?php
+
+/** @var string $name */
+/** @var string $slug */
+/** @var string[] $options */
+
+/** @var string $fieldId */
+$fieldId = 'spf-meta-' . $slug;
+$datalistId = $fieldId.'-datalist';
+
+/** @var string $value The current value of the custom field. */
+$value = esc_attr(get_post_meta(get_post()->ID, $slug, true));
+
+?>
+
+<table class="form-table">
+    <tbody>
+    <tr>
+        <th scope="row">
+            <label for="<?= $fieldId; ?>"><?= $name; ?>: </label>
+        </th>
+        <td>
+            <input list="<?= $datalistId  ?>" name="<?= $fieldId; ?>" value="<?= $value; ?>"/>
+			<datalist id="<?= $datalistId; ?>">
+				<?php foreach ($options as $key=>$value) : ?>
+					<option value="<?= $key; ?>"><?= $value; ?></option>
+				<?php endforeach; ?>
+			</datalist>
+		</td>
+    </tr>
+    </tbody>
+</table>

--- a/src/MetaBoxViews/AssociativeMultiSelect.php
+++ b/src/MetaBoxViews/AssociativeMultiSelect.php
@@ -1,0 +1,31 @@
+<?php
+
+/** @var string $name */
+/** @var string $slug */
+/** @var string[] $options */
+
+/** @var string $fieldId */
+$fieldId = 'spf-multi-meta-' . $slug;
+
+/** @var string $value The current value of the custom field. */
+$currentValue = get_post_meta(get_post()->ID, $slug, true);
+$currentValue = json_decode($currentValue);
+?>
+
+<table class="form-table">
+    <tbody>
+    <tr>
+        <th scope="row">
+            <label for="<?= $fieldId; ?>"><?= $name; ?>: </label>
+        </th>
+        <td>
+            <select multiple name="<?= $fieldId; ?>[]">
+                <?php if (is_array($options)) { foreach ($options as $option=>$description) : ?>
+                    <?php $selected = (in_array($option,$currentValue)) ? 'selected="selected"' : ''; ?>
+                    <option value="<?= $option; ?>" <?= $selected; ?>><?= $description; ?></option>
+                <?php endforeach; } ?>
+            </select>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/src/MetaBoxViews/AssociativeSelect.php
+++ b/src/MetaBoxViews/AssociativeSelect.php
@@ -1,0 +1,31 @@
+<?php
+
+/** @var string $name */
+/** @var string $slug */
+/** @var string[] $options */
+
+/** @var string $fieldId */
+$fieldId = 'spf-meta-' . $slug;
+
+/** @var string $value The current value of the custom field. */
+$currentValue = esc_attr(get_post_meta(get_post()->ID, $slug, true));
+
+?>
+
+<table class="form-table">
+    <tbody>
+    <tr>
+        <th scope="row">
+            <label for="<?= $fieldId; ?>"><?= $name; ?>: </label>
+        </th>
+        <td>
+            <select name="<?= $fieldId; ?>">
+                <?php foreach ($options as $option=>$description) : ?>
+                    <?php $selected = ($option == $currentValue) ? 'selected="selected"' : ''; ?>
+                    <option value="<?= $option; ?>" <?= $selected; ?>><?= $description; ?></option>
+                <?php endforeach; ?>
+            </select>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/src/MetaBoxViews/AutoCompleteInput.php
+++ b/src/MetaBoxViews/AutoCompleteInput.php
@@ -1,0 +1,32 @@
+<?php
+
+/** @var string $name */
+/** @var string $slug */
+/** @var string[] $options */
+
+/** @var string $fieldId */
+$fieldId = 'spf-meta-' . $slug;
+$datalistId = $fieldId.'-datalist';
+
+/** @var string $value The current value of the custom field. */
+$value = esc_attr(get_post_meta(get_post()->ID, $slug, true));
+
+?>
+
+<table class="form-table">
+    <tbody>
+    <tr>
+        <th scope="row">
+            <label for="<?= $fieldId; ?>"><?= $name; ?>: </label>
+        </th>
+        <td>
+            <input list="<?= $datalistId  ?>" name="<?= $fieldId; ?>" value="<?= $value; ?>"/>
+			<datalist id="<?= $datalistId; ?>">
+				<?php foreach ($options as $option) : ?>
+					<option value="<?= $option; ?>"><?= $option; ?></option>
+				<?php endforeach; ?>
+			</datalist>
+		</td>
+    </tr>
+    </tbody>
+</table>

--- a/src/MetaBoxViews/ConstrainedNumber.php
+++ b/src/MetaBoxViews/ConstrainedNumber.php
@@ -1,0 +1,26 @@
+<?php
+
+/** @var string $name */
+/** @var string $slug */
+/** @var string $attributes */
+
+/** @var string $fieldId */
+$fieldId = 'spf-meta-' . $slug;
+
+/** @var string $value The current value of the custom field. */
+$value = esc_attr(get_post_meta(get_post()->ID, $slug, true));
+
+?>
+
+<table class="form-table">
+    <tbody>
+    <tr>
+        <th scope="row">
+            <label for="<?= $fieldId; ?>"><?= $name; ?>: </label>
+        </th>
+        <td>
+            <input type="number" name="<?= $fieldId; ?>" <?= $attributes; ?>></input>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/src/MetaBoxViews/MultiSelect.php
+++ b/src/MetaBoxViews/MultiSelect.php
@@ -1,0 +1,31 @@
+<?php
+
+/** @var string $name */
+/** @var string $slug */
+/** @var string[] $options */
+
+/** @var string $fieldId */
+$fieldId = 'spf-multi-meta-' . $slug;
+
+/** @var string $value The current value of the custom field. */
+$currentValue = esc_attr(get_post_meta(get_post()->ID, $slug, true));
+
+?>
+
+<table class="form-table">
+    <tbody>
+    <tr>
+        <th scope="row">
+            <label for="<?= $fieldId; ?>"><?= $name; ?>: </label>
+        </th>
+        <td>
+            <select multiple name="<?= $fieldId; ?>[]">
+                <?php foreach ($options as $option) : ?>
+                    <?php $selected = ($option == $currentValue) ? 'selected="selected"' : ''; ?>
+                    <option value="<?= $option; ?>" <?= $selected; ?>><?= $option; ?></option>
+                <?php endforeach; ?>
+            </select>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/src/MetaBox_Extended.php
+++ b/src/MetaBox_Extended.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: emanuele
+ * Date: 22/11/15
+ * Time: 18:30
+ */
+
+namespace theantichris\SPF;
+
+class MetaBox_Extended extends MetaBox
+{
+	function __construct($name, $postTypes, $viewFile, $viewData = array())
+	{
+		parent::__construct($name, $postTypes, $viewFile, $viewData);
+		add_action('save_post', array($this, 'saveMetaBox_Extended'));
+	}
+
+	public static function MultiSelectInput($name, $slug, $options)
+	{
+		$viewData = array(
+			'name'    => $name,
+			'slug'    => $slug,
+			'options' => $options,
+		);
+
+		View::render(__DIR__ . '/MetaBoxViews/MultiSelect.php', $viewData);
+	}
+
+	public static function AssociativeSelectInput($name, $slug, $options)
+	{
+		$viewData = array(
+			'name'    => $name,
+			'slug'    => $slug,
+			'options' => $options,
+		);
+
+		View::render(__DIR__ . '/MetaBoxViews/AssociativeSelect.php', $viewData);
+	}
+
+	public static function AssociativeMultiSelectInput($name, $slug, $options)
+	{
+		$viewData = array(
+			'name'    => $name,
+			'slug'    => $slug,
+			'options' => $options,
+		);
+
+		View::render(__DIR__ . '/MetaBoxViews/AssociativeMultiSelect.php', $viewData);
+	}
+
+	public static function AutoCompleteInput($name, $slug, $options)
+	{
+		$viewData = array(
+			'name'    => $name,
+			'slug'    => $slug,
+			'options' => $options,
+		);
+
+		View::render(__DIR__ . '/MetaBoxViews/AutoCompleteInput.php', $viewData);
+	}
+
+	public static function AssociativeAutoCompleteInput($name, $slug, $options)
+	{
+		$viewData = array(
+			'name'    => $name,
+			'slug'    => $slug,
+			'options' => $options,
+		);
+
+		View::render(__DIR__ . '/MetaBoxViews/AssociativeAutoCompleteInput.php', $viewData);
+	}
+
+	public static function ConstrainedNumberInput($name, $slug, $min='', $max='', $value='')
+	{
+		$viewData = array(
+			'name'       => $name,
+			'slug'       => $slug,
+			'attributes' => ' min="' . $min . '"' . ' max="' . $max . '"' . ' value="' . $value . '"',
+		);
+
+		View::render(__DIR__ . '/MetaBoxViews/ConstrainedNumber.php', $viewData);
+	}
+
+	public function saveMetaBox_Extended($postId)
+	{
+		foreach ($_POST as $key => $value)
+		{
+			if ( strpos( $key, 'spf-multi-meta-' ) !== false ) {
+				$key = str_replace( 'spf-multi-meta-', '', $key );
+				update_post_meta( $postId, $key, json_encode($value) );
+			}
+		}
+	}
+}

--- a/src/PostType_Extended.php
+++ b/src/PostType_Extended.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: emanuele
+ * Date: 01/12/15
+ * Time: 10:26
+ */
+
+namespace theantichris\SPF;
+
+
+class PostType_Extended extends PostType
+{
+	/** @var string[] An array of labels for this post type. */
+	private $labels;
+	/** @var string A short descriptive summary of what the post type is. */
+	private $description;
+	/** @var bool Whether a post type is intended to be used publicly either via the admin interface or by front-end users. */
+	private $public = true;
+	/** @var int The position in the menu order the post type should appear. */
+	private $menuPosition;
+	/** @var  string The url to the icon to be used for this menu or the name of the icon from the iconfont */
+	private $menuIcon;
+	/** @var string[] Capabilities to set for the post type. */
+	/** @var string[]|bool $supports Registers support of certain features for a given post type. */
+	private $supports = array('title', 'editor');
+
+	function __construct($name, $slug)
+	{
+		$this->name   = $name;
+		$this->slug   = $slug;
+		$this->labels = $this->setLabels();
+
+		add_action('init', array($this, 'registerPostType'));
+	}
+
+	/**
+	 * Sets up the labels for the post type..
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string[]
+	 */
+	private function setLabels()
+	{
+		$singular = Helper::makeSingular($this->name);
+
+		$textDomain = parent::$textDomain;
+
+		$labels = array(
+			'name'               => __($this->name, $textDomain),
+			'singular_name'      => __($singular, $textDomain),
+			'add_new'            => __('Add New', $textDomain),
+			'add_new_item'       => __('Add New ' . $singular, $textDomain),
+			'edit_item'          => __('Edit ' . $singular, $textDomain),
+			'new_item'           => __('New ' . $singular, $textDomain),
+			'all_items'          => __('All ' . $this->name, $textDomain),
+			'view_item'          => __('View ' . $singular, $textDomain),
+			'search_items'       => __('Search ' . $this->name, $textDomain),
+			'not_found'          => __('No ' . strtolower($this->name) . ' found.', $textDomain),
+			'not_found_in_trash' => __('No ' . strtolower($this->name) . ' found in Trash.', $textDomain),
+			'parent_item_colon'  => '',
+			'menu_name'          => __($this->name, $textDomain)
+		);
+
+		return $labels;
+	}
+
+	/**
+	 * Calls the WordPress function register_post_type() if the post type does not already exist.
+	 * This function should not be called directly. It is only public so WordPress can call it.
+	 * @link http://codex.wordpress.org/Function_Reference/register_post_type
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	/**
+	 * Sets $capabilities if all capabilities are valid.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string[] $capabilities An array of the capabilities for this post type.
+	 * @return PostType
+	 */
+	public function setSupports($supports)
+	{
+		if ($supports === true) {
+			wp_die(__("The supports option must be an array or false", parent::$textDomain));
+		}
+
+		$this->supports = $supports;
+
+		return $this;
+	}
+
+	public function setCapabilities($capabilities)
+	{
+		return wp_die(__("Setting capabilities for PostType_Extended objects is forbidden"), parent::$textDomain);
+	}
+
+	public function registerPostType()
+	{
+		if (!post_type_exists($this->getSlug())) {
+			$arguments = array(
+				'labels'        => $this->labels,
+				'description'   => $this->description,
+				'public'        => $this->public,
+				'menu_position' => $this->menuPosition,
+				'menu_icon'     => $this->menuIcon,
+				'capability_type'  => $this->getSlug(),
+				'supports'      => $this->supports,
+				'map_meta_cap'  => true
+			);
+
+			register_post_type($this->getSlug(), $arguments);
+		}
+	}
+}


### PR DESCRIPTION
Hi,
I have done several slight modifications to the framework: 
- Add Autocomplete Input, Multi Select, Constrained Number metabox views
- Extended PostType to allow map_meta_cap (I had to lockdown the WP backend for a project and show only the custom posts for some user types)
